### PR TITLE
Add support for Google Colab

### DIFF
--- a/whiteboxgui/__init__.py
+++ b/whiteboxgui/__init__.py
@@ -4,4 +4,10 @@ __author__ = """Qiusheng Wu"""
 __email__ = 'giswqs@gmail.com'
 __version__ = '2.2.0'
 
+import sys
+
 from .whiteboxgui import show, update_package
+
+if "google.colab" in sys.modules:
+    from google.colab import output
+    output.enable_custom_widget_manager()


### PR DESCRIPTION
Runs the following code block automatically if on Google Colab. 

```python
from google.colab import output
output.enable_custom_widget_manager()
```